### PR TITLE
Fixed crash when initial View is marked as ActivePanel

### DIFF
--- a/MvvmCross.iOS.Support.XamarinSidebar/Hints/MvxSidebarResetRootPresentationHint.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/Hints/MvxSidebarResetRootPresentationHint.cs
@@ -3,11 +3,11 @@ using MvvmCross.iOS.Support.SidePanels;
 
 namespace MvvmCross.iOS.Support.XamarinSidebar.Hints
 {
-    public class MvxSidebarPopToRootPresentationHint : MvxPanelPresentationHint
+    public class MvxSidebarResetRootPresentationHint : MvxPanelPresentationHint
     {
-        public MvxSidebarPopToRootPresentationHint(MvxPanelEnum panel, MvxSidebarPanelController sidebarPanelController, UIViewController viewController)
+        public MvxSidebarResetRootPresentationHint(MvxPanelEnum panel, MvxSidebarPanelController sidebarPanelController, UIViewController viewController)
             : base(panel)
-        {
+        { 
             SidebarPanelController = sidebarPanelController;
             ViewController = viewController;
         }
@@ -25,8 +25,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Hints
             if (navigationController == null)
                 return false;
 
-            navigationController.PopToRootViewController(false);
-            navigationController.PushViewController(ViewController, false);
+            navigationController.ViewControllers = new UIViewController[] { ViewController };
 
             return true;
         }

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvvmCross.iOS.Support.XamarinSidebar.csproj
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvvmCross.iOS.Support.XamarinSidebar.csproj
@@ -64,10 +64,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Hints\MvxSidebarPopToRootPresentationHint.cs" />
+    <Compile Include="Hints\MvxSidebarResetRootPresentationHint.cs" />
     <Compile Include="Hints\MvxSidebarActivePanelPresentationHint.cs" />
     <Compile Include="MvxSidebarPresenter.cs" />
     <Compile Include="MvxSidebarPanelController.cs" />
+    <Compile Include="Hints\MvxSidebarPopToRootPresentationHint.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Views/CenterPanelView.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Views/CenterPanelView.cs
@@ -11,7 +11,7 @@ namespace MvvmCross.iOS.Support.iOS.Views
     using UIKit;
 
     [Register("CenterPanelView")]
-    [MvxPanelPresentation(MvxPanelEnum.Center, MvxPanelHintType.PopToRoot, true)]
+    [MvxPanelPresentation(MvxPanelEnum.Center, MvxPanelHintType.ActivePanel, true)]
     public class CenterPanelView : BaseViewController<CenterPanelViewModel>
     {
         /// <summary>

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
@@ -10,7 +10,7 @@ namespace MvvmCross.iOS.Support.iOS.Views
     using UIKit;
 
     [Register("MasterView")]
-    [MvxPanelPresentation(MvxPanelEnum.Center, MvxPanelHintType.PopToRoot, true, MvxSplitViewBehaviour.Master)]
+    [MvxPanelPresentation(MvxPanelEnum.Center, MvxPanelHintType.ResetRoot, true, MvxSplitViewBehaviour.Master)]
     public class MasterView : BaseViewController<MasterViewModel>
     {
         /// <summary>


### PR DESCRIPTION
This pull request fixes two issues:
1. It fixes a crash when the initial view that is loaded is marked with the `MvxPanelPresentation` attribute and set to be an `ActivePanel`.
2. Changed the implementation of the `MvxPanelPopToRootPresentationHint` to pop to the root view on the navigation controller and add the view on top of this root. The old implementation is now available in the `MvxPanelResetRootPresentationHint`. This makes more sense as it will replace the current root view with the root view that is being loaded. In other words, if you want to replace the root view with your new view use the `MvxPanelHintType.ResetRoot`, if you just want to add your view on top of the root view use the `MvxPanelHintType.PopToRoot` with the `MvxPanelPresentation` attribute. 
