### PR TITLE
Added support to programmatically toggle the menu

### DIFF
--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -6,12 +6,11 @@ using MvvmCross.Platform.Exceptions;
 using System.Linq;
 using UIKit;
 using MvvmCross.iOS.Support.SidePanels;
-using SidebarNavigation;
 using MvvmCross.iOS.Support.XamarinSidebar.Hints;
 
 namespace MvvmCross.iOS.Support.XamarinSidebar
 {
-    public class MvxSidebarPresenter : MvxIosViewPresenter
+    public class MvxSidebarPresenter : MvxIosViewPresenter, IMvxToggleMenu
     {
         protected virtual MvxSidebarPanelController SidebarPanelController { get; private set;}
 
@@ -95,7 +94,10 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
             SetWindowRootViewController(SidebarPanelController);
         }
-            
 
+        public void Toggle()
+        {
+            SidebarPanelController?.SidebarController?.ToggleMenu();
+        }
     }
 }

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -10,7 +10,7 @@ using MvvmCross.iOS.Support.XamarinSidebar.Hints;
 
 namespace MvvmCross.iOS.Support.XamarinSidebar
 {
-    public class MvxSidebarPresenter : MvxIosViewPresenter, IMvxToggleMenu
+    public class MvxSidebarPresenter : MvxIosViewPresenter, IMvxSideMenu
     {
         protected virtual MvxSidebarPanelController SidebarPanelController { get; private set;}
 
@@ -95,7 +95,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             SetWindowRootViewController(SidebarPanelController);
         }
 
-        public void Toggle()
+        public void ToggleMenu()
         {
             SidebarPanelController?.SidebarController?.ToggleMenu();
         }

--- a/MvvmCross.iOS.Support/MvvmCross.iOS.Support.csproj
+++ b/MvvmCross.iOS.Support/MvvmCross.iOS.Support.csproj
@@ -76,6 +76,7 @@
     <Compile Include="SidePanels\MvxPanelPushViewPresentationHint.cs" />
     <Compile Include="SidePanels\MvxPanelPopToRootPresentationHint.cs" />
     <Compile Include="SidePanels\MvxPanelPresentationHint.cs" />
+    <Compile Include="SidePanels\IMvxToggleMenu.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/MvvmCross.iOS.Support/SidePanels/IMvxSideMenu.cs
+++ b/MvvmCross.iOS.Support/SidePanels/IMvxSideMenu.cs
@@ -1,8 +1,8 @@
 ﻿namespace MvvmCross.iOS.Support.SidePanels
 {
-    public interface IMvxToggleMenu
+    public interface IMvxSideMenu
     {
-        void Toggle();
+        void ToggleMenu();
     }
 }
 

--- a/MvvmCross.iOS.Support/SidePanels/IMvxToggleMenu.cs
+++ b/MvvmCross.iOS.Support/SidePanels/IMvxToggleMenu.cs
@@ -1,0 +1,8 @@
+﻿namespace MvvmCross.iOS.Support.SidePanels
+{
+    public interface IMvxToggleMenu
+    {
+        void Toggle();
+    }
+}
+

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
@@ -40,8 +40,7 @@ namespace MvvmCross.iOS.Support.Sidebar
 		{
 			var presenter = new MvxSidebarPresenter((MvxApplicationDelegate)ApplicationDelegate, Window);
 
-            if(presenter is IMvxSideMenu)
-                Mvx.RegisterSingleton<IMvxSideMenu>(presenter);
+            Mvx.RegisterSingleton<IMvxSideMenu>(presenter);
 
             return presenter;
 		}

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
@@ -40,8 +40,8 @@ namespace MvvmCross.iOS.Support.Sidebar
 		{
 			var presenter = new MvxSidebarPresenter((MvxApplicationDelegate)ApplicationDelegate, Window);
 
-            if(presenter is IMvxToggleMenu)
-                Mvx.RegisterSingleton<IMvxToggleMenu>(presenter);
+            if(presenter is IMvxSideMenu)
+                Mvx.RegisterSingleton<IMvxSideMenu>(presenter);
 
             return presenter;
 		}

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
@@ -3,9 +3,10 @@ using MvvmCross.iOS.Support.XamarinSidebar;
 
 namespace MvvmCross.iOS.Support.Sidebar
 {
-	using MvvmCross.Core;
-	using MvvmCross.iOS.Platform;
+	using MvvmCross.Platform;
+    using MvvmCross.iOS.Platform;
 	using MvvmCross.iOS.Views.Presenters;
+    using MvvmCross.iOS.Support.SidePanels;
 	using MvvmCross.Platform.Platform;
 	using UIKit;
 	using MvvmCross.Core.ViewModels;
@@ -37,7 +38,12 @@ namespace MvvmCross.iOS.Support.Sidebar
 
 		protected override IMvxIosViewPresenter CreatePresenter()
 		{
-			return new MvxSidebarPresenter((MvxApplicationDelegate)ApplicationDelegate, Window);
+			var presenter = new MvxSidebarPresenter((MvxApplicationDelegate)ApplicationDelegate, Window);
+
+            if(presenter is IMvxToggleMenu)
+                Mvx.RegisterSingleton<IMvxToggleMenu>(presenter);
+
+            return presenter;
 		}
 	}
 }

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
@@ -1,8 +1,7 @@
-﻿using MvvmCross.iOS.Support.SidePanels;
-using MvvmCross.iOS.Support.XamarinSidebar;
-
-namespace MvvmCross.iOS.Support.iOS.Views
+﻿namespace MvvmCross.iOS.Support.iOS.Views
 {
+    using MvvmCross.Platform;
+    using MvvmCross.iOS.Support.SidePanels;
     using Binding.BindingContext;
     using Cirrious.FluentLayouts.Touch;
     using Core.ViewModels;
@@ -32,6 +31,14 @@ namespace MvvmCross.iOS.Support.iOS.Views
             var detailButton = new UIButton();
             detailButton.SetTitle("Show Detail", UIControlState.Normal);
 
+            var toggleMenuButton = new UIButton();
+            toggleMenuButton.SetTitle("Toggle menu", UIControlState.Normal);
+            toggleMenuButton.TouchUpInside += (s, e) =>
+            {
+                var menuToggler = Mvx.Resolve<IMvxToggleMenu>();
+                menuToggler?.Toggle();
+            };
+
             var bindingSet = this.CreateBindingSet<MasterView, MasterViewModel>();
             bindingSet.Bind(label).To(vm => vm.ExampleValue);
             bindingSet.Bind(detailButton).To(vm => vm.ShowDetailCommand);
@@ -39,6 +46,7 @@ namespace MvvmCross.iOS.Support.iOS.Views
 
             Add(label);
             Add(detailButton);
+            Add(toggleMenuButton);
 
             View.SubviewsDoNotTranslateAutoresizingMaskIntoConstraints();
 
@@ -48,7 +56,10 @@ namespace MvvmCross.iOS.Support.iOS.Views
                 label.WithSameCenterY(View),
 
                 detailButton.Below(label, 10),
-                detailButton.WithSameCenterX(View)
+                detailButton.WithSameCenterX(View),
+
+                toggleMenuButton.Below(detailButton, 10),
+                toggleMenuButton.WithSameCenterX(View)
 
                 );
 

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
@@ -35,8 +35,8 @@
             toggleMenuButton.SetTitle("Toggle menu", UIControlState.Normal);
             toggleMenuButton.TouchUpInside += (s, e) =>
             {
-                var menuToggler = Mvx.Resolve<IMvxToggleMenu>();
-                menuToggler?.Toggle();
+                var menuToggler = Mvx.Resolve<IMvxSideMenu>();
+                menuToggler?.ToggleMenu();
             };
 
             var bindingSet = this.CreateBindingSet<MasterView, MasterViewModel>();


### PR DESCRIPTION
To programmatically toggle the menu request an implementation of the `IMvxToggleMenu` interface from the Mvx IoC container:

`var menuToggler = Mvx.Resolve<IMvxToggleMenu>();`

Of course you also need to make sure you register the appropriate instance. This can be done in the `Setup` class of the project using something like the following code:

```
var presenter = new MvxSidebarPresenter((MvxApplicationDelegate)ApplicationDelegate, Window);
if(presenter is IMvxToggleMenu)
    Mvx.RegisterSingleton<IMvxToggleMenu>(presenter);

return presenter;
```
