### PR TITLE
Added support to use left and right menu

### DIFF
--- a/MvvmCross.iOS.Support.JASidePanels/MvxMultiPanelController.cs
+++ b/MvvmCross.iOS.Support.JASidePanels/MvxMultiPanelController.cs
@@ -1,10 +1,11 @@
 ﻿using JASidePanels;
+using MvvmCross.iOS.Support.SidePanels;
 
 namespace MvvmCross.iOS.Support.JASidePanels
 {
     using UIKit;
 
-    public class MvxMultiPanelController : JASidePanelController
+    public class MvxMultiPanelController : JASidePanelController, IMvxSideMenu
     {
         /// <summary>
         /// Method s simply overridden to remove any styling such as the default corner radius.
@@ -13,6 +14,21 @@ namespace MvvmCross.iOS.Support.JASidePanels
         public override void StylePanel(UIView panel)
         {
 			
+        }
+
+        public void Close()
+        {
+            ShowCenterPanelAnimated(false);
+        }
+
+        public void Open(MvxPanelEnum panelEnum)
+        {
+            if (panelEnum == MvxPanelEnum.Left)
+                ShowLeftPanelAnimated(false);
+            else if (panelEnum == MvxPanelEnum.Right)
+                ShowRightPanelAnimated(false);
+            else
+                ShowCenterPanelAnimated(false);
         }
     }
 }

--- a/MvvmCross.iOS.Support.JASidePanels/MvxSidePanelsPresenter.cs
+++ b/MvvmCross.iOS.Support.JASidePanels/MvxSidePanelsPresenter.cs
@@ -3,6 +3,7 @@ using MvvmCross.iOS.Views;
 using MvvmCross.iOS.Views.Presenters;
 using MvvmCross.Platform.Exceptions;
 using MvvmCross.Platform.Platform;
+using MvvmCross.Platform;
 
 namespace MvvmCross.iOS.Support.JASidePanels
 {
@@ -54,6 +55,8 @@ namespace MvvmCross.iOS.Support.JASidePanels
         {
             _multiPanelController = new MvxMultiPanelController();
             _activePanel = MvxPanelEnum.Center;
+
+            Mvx.RegisterSingleton<IMvxSideMenu>(_multiPanelController);
         }
 
         #endregion ctors

--- a/MvvmCross.iOS.Support.XamarinSidebar/Hints/MvxSidebarActivePanelPresentationHint.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/Hints/MvxSidebarActivePanelPresentationHint.cs
@@ -42,7 +42,10 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Hints
 
         protected virtual void InitSidebar()
         {
-            var sidebarController = SidebarPanelController.SidebarController;
+            var sidebarController = Panel == MvxPanelEnum.Left 
+                                                         ? SidebarPanelController.LeftSidebarController 
+                                                         : SidebarPanelController.RightSidebarController;
+
             var barButtonItem = new UIBarButtonItem(UIImage.FromBundle("threelines")
                 , UIBarButtonItemStyle.Plain
                 , (sender, args) => sidebarController.ToggleMenu());

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -1,12 +1,16 @@
 ﻿using SidebarNavigation;
 using UIKit;
+using MvvmCross.iOS.Support.SidePanels;
 
 namespace MvvmCross.iOS.Support.XamarinSidebar
 {
-    public class MvxSidebarPanelController : UIViewController
+    public class MvxSidebarPanelController : UIViewController, IMvxSideMenu
     {
+        private readonly UIViewController _subRootViewController;
+
         public MvxSidebarPanelController(UINavigationController navigationController)
         {
+            _subRootViewController = new UIViewController();
             NavigationController = navigationController;
         }
 
@@ -20,10 +24,32 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
             var initialEmptySideMenu = new UIViewController();
 
-            LeftSidebarController = new SidebarController(this, NavigationController, initialEmptySideMenu);
-            RightSidebarController = new SidebarController(this, NavigationController, initialEmptySideMenu);
+            LeftSidebarController = new SidebarController(_subRootViewController, NavigationController, initialEmptySideMenu);
+            RightSidebarController = new SidebarController(this, _subRootViewController, initialEmptySideMenu);
         }
 
+        public void Close()
+        {
+            if (LeftSidebarController != null && LeftSidebarController.IsOpen)
+                LeftSidebarController.CloseMenu();
+
+            if (RightSidebarController != null && RightSidebarController.IsOpen)
+                RightSidebarController.CloseMenu();
+        }
+
+        public void Open(MvxPanelEnum panelEnum)
+        {
+            if (panelEnum == MvxPanelEnum.Left)
+                OpenMenu(LeftSidebarController);
+            else if (panelEnum == MvxPanelEnum.Right)
+                OpenMenu(RightSidebarController);
+        }
+
+        private void OpenMenu(SidebarController sidebarController)
+        {
+            if (sidebarController != null && !sidebarController.IsOpen)
+                sidebarController.OpenMenu();
+        }
     }
 }
 

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -11,7 +11,8 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
         }
 
         public UINavigationController NavigationController { get; private set; }
-        public SidebarController SidebarController { get; private set; }
+        public SidebarController LeftSidebarController { get; private set; }
+        public SidebarController RightSidebarController { get; private set; }
 
         public override void ViewDidLoad()
         {
@@ -19,7 +20,8 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
             var initialEmptySideMenu = new UIViewController();
 
-            SidebarController = new SidebarController(this, NavigationController, initialEmptySideMenu);
+            LeftSidebarController = new SidebarController(this, NavigationController, initialEmptySideMenu);
+            RightSidebarController = new SidebarController(this, NavigationController, initialEmptySideMenu);
         }
 
     }

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -95,9 +95,17 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             SetWindowRootViewController(SidebarPanelController);
         }
 
-        public void ToggleMenu()
+        public void Close()
         {
-            SidebarPanelController?.SidebarController?.ToggleMenu();
+            var sidebarPanelController = SidebarPanelController;
+
+            if (sidebarPanelController == null) return;
+
+            if (sidebarPanelController.LeftSidebarController.IsOpen)
+                sidebarPanelController.LeftSidebarController.CloseMenu();
+
+            if (sidebarPanelController.RightSidebarController.IsOpen)
+                sidebarPanelController.RightSidebarController.CloseMenu();
         }
     }
 }

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -10,9 +10,9 @@ using MvvmCross.iOS.Support.XamarinSidebar.Hints;
 
 namespace MvvmCross.iOS.Support.XamarinSidebar
 {
-    public class MvxSidebarPresenter : MvxIosViewPresenter, IMvxSideMenu
+    public class MvxSidebarPresenter : MvxIosViewPresenter
     {
-        protected virtual MvxSidebarPanelController SidebarPanelController { get; private set;}
+        protected virtual MvxSidebarPanelController RootViewController { get; private set;}
 
         public MvxSidebarPresenter(IUIApplicationDelegate applicationDelegate, UIWindow window)
             : base(applicationDelegate, window)
@@ -51,9 +51,9 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             if (viewController == null)
                 throw new MvxException("Passed in IMvxIosView is not a UIViewController");
 
-            if (this.SidebarPanelController == null)
+            if (this.RootViewController == null)
             {
-                this.InitSidebarController();
+                this.InitRootViewController();
             }
 
             var viewPresentationAttribute = GetViewPresentationAttribute(view);
@@ -61,14 +61,14 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             switch (viewPresentationAttribute.HintType)
             {
 				case MvxPanelHintType.PopToRoot:
-                    ChangePresentation(new MvxSidebarPopToRootPresentationHint(viewPresentationAttribute.Panel, SidebarPanelController, viewController));
+                    ChangePresentation(new MvxSidebarPopToRootPresentationHint(viewPresentationAttribute.Panel, RootViewController, viewController));
                     break;
                 case MvxPanelHintType.ResetRoot:
-                    ChangePresentation(new MvxSidebarResetRootPresentationHint(viewPresentationAttribute.Panel, SidebarPanelController, viewController));
+                    ChangePresentation(new MvxSidebarResetRootPresentationHint(viewPresentationAttribute.Panel, RootViewController, viewController));
                     break;
 				case MvxPanelHintType.ActivePanel:
                     default:
-                    ChangePresentation(new MvxSidebarActivePanelPresentationHint(viewPresentationAttribute.Panel, SidebarPanelController, viewController));
+                    ChangePresentation(new MvxSidebarActivePanelPresentationHint(viewPresentationAttribute.Panel, RootViewController, viewController));
                     break;
             }
 		}
@@ -81,7 +81,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
             return view.GetType().GetCustomAttributes(typeof(MvxPanelPresentationAttribute), true).FirstOrDefault() as MvxPanelPresentationAttribute;
         }	
 
-        protected virtual void InitSidebarController()
+        protected virtual void InitRootViewController()
         {
             foreach (var view in Window.Subviews)
                 view.RemoveFromSuperview();
@@ -90,22 +90,13 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
             this.OnMasterNavigationControllerCreated();
 
-            SidebarPanelController = new MvxSidebarPanelController(MasterNavigationController);
+            RootViewController = new MvxSidebarPanelController(MasterNavigationController);
 
-            SetWindowRootViewController(SidebarPanelController);
+            SetWindowRootViewController(RootViewController);
+
+            Mvx.RegisterSingleton<IMvxSideMenu>(RootViewController);
         }
 
-        public void Close()
-        {
-            var sidebarPanelController = SidebarPanelController;
 
-            if (sidebarPanelController == null) return;
-
-            if (sidebarPanelController.LeftSidebarController.IsOpen)
-                sidebarPanelController.LeftSidebarController.CloseMenu();
-
-            if (sidebarPanelController.RightSidebarController.IsOpen)
-                sidebarPanelController.RightSidebarController.CloseMenu();
-        }
     }
 }

--- a/MvvmCross.iOS.Support/SidePanels/IMvxSideMenu.cs
+++ b/MvvmCross.iOS.Support/SidePanels/IMvxSideMenu.cs
@@ -2,7 +2,11 @@
 {
     public interface IMvxSideMenu
     {
-        void ToggleMenu();
+        /// <summary>
+        /// Closes the active menu, if none are open nothing will happen.
+        /// When multiple are open, all will close.
+        /// </summary>
+        void Close();
     }
 }
 

--- a/MvvmCross.iOS.Support/SidePanels/IMvxSideMenu.cs
+++ b/MvvmCross.iOS.Support/SidePanels/IMvxSideMenu.cs
@@ -7,6 +7,12 @@
         /// When multiple are open, all will close.
         /// </summary>
         void Close();
+
+        /// <summary>
+        /// Opens the left or the right menu (as indicated by the parameter).
+        /// </summary>
+        /// <param name="panelEnum">Indicates if either the left or the right menu should be opened.</param>
+        void Open(MvxPanelEnum panelEnum);
     }
 }
 

--- a/Samples/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
+++ b/Samples/MvvmCross.iOS.Support.Core/ViewModels/MasterViewModel.cs
@@ -26,6 +26,7 @@
         {
             // Loads the flyout menu on the left
             ShowViewModel<LeftPanelViewModel>();
+            ShowViewModel<RightPanelViewModel>();
         }
     }
 }

--- a/Samples/MvvmCross.iOS.Support.Sidebar/MvvmCross.iOS.Support.Sidebar.csproj
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/MvvmCross.iOS.Support.Sidebar.csproj
@@ -154,6 +154,10 @@
       <Project>{E6A71CD5-82A0-49E9-A04D-166F9E8F76F9}</Project>
       <Name>MvvmCross.iOS.Support</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\MvvmCross.iOS.Support.JASidePanels\MvvmCross.iOS.Support.JASidePanels.csproj">
+      <Project>{0E866698-7054-4786-A43F-E6E0E99D90A1}</Project>
+      <Name>MvvmCross.iOS.Support.JASidePanels</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Setup.cs
@@ -38,11 +38,7 @@ namespace MvvmCross.iOS.Support.Sidebar
 
 		protected override IMvxIosViewPresenter CreatePresenter()
 		{
-			var presenter = new MvxSidebarPresenter((MvxApplicationDelegate)ApplicationDelegate, Window);
-
-            Mvx.RegisterSingleton<IMvxSideMenu>(presenter);
-
-            return presenter;
+			return new MvxSidebarPresenter((MvxApplicationDelegate)ApplicationDelegate, Window);
 		}
 	}
 }

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
@@ -35,8 +35,8 @@
             toggleMenuButton.SetTitle("Toggle menu", UIControlState.Normal);
             toggleMenuButton.TouchUpInside += (s, e) =>
             {
-                var menuToggler = Mvx.Resolve<IMvxSideMenu>();
-                menuToggler?.ToggleMenu();
+                var sideMenu = Mvx.Resolve<IMvxSideMenu>();
+                sideMenu?.Close();
             };
 
             var bindingSet = this.CreateBindingSet<MasterView, MasterViewModel>();

--- a/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
+++ b/Samples/MvvmCross.iOS.Support.Sidebar/Views/MasterView.cs
@@ -32,11 +32,11 @@
             detailButton.SetTitle("Show Detail", UIControlState.Normal);
 
             var toggleMenuButton = new UIButton();
-            toggleMenuButton.SetTitle("Toggle menu", UIControlState.Normal);
+            toggleMenuButton.SetTitle("Open menu", UIControlState.Normal);
             toggleMenuButton.TouchUpInside += (s, e) =>
             {
                 var sideMenu = Mvx.Resolve<IMvxSideMenu>();
-                sideMenu?.Close();
+                sideMenu?.Open(MvxPanelEnum.Left);
             };
 
             var bindingSet = this.CreateBindingSet<MasterView, MasterViewModel>();


### PR DESCRIPTION
Added support for displaying left and right menu buttons on the same view. This allows you to use a left and right menu at the same time in your application.

Note: I had to rename the IMvxSideMenu interface's 'ToggleMenu' method to 'Close' since it no longer toggles the menu, it simply closes the menu that is active. This leaves three options:
- if neither the left or the right menu is open nothing happens;
- if either the left or the right menu is open it closes the open menu;
- if both menus are open the 'Close' method closes both menus.
