### PR TITLE
Handle default behaviour for SidePanel presenter

### DIFF
--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -61,6 +61,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 			//Create fall back viewPresentationAttribute, when nothing is set
 			if (viewPresentationAttribute == null)
 			{
+				Mvx.Warning("No " + nameof(MvxPanelPresentationAttribute) + " has been set, each viewcontroller should provide one.");
 				viewPresentationAttribute = new MvxPanelPresentationAttribute(MvxPanelEnum.Center, MvxPanelHintType.ActivePanel, true);
 			}
 

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -58,6 +58,12 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
             var viewPresentationAttribute = GetViewPresentationAttribute(view);
 
+			//Create fall back viewPresentationAttribute, when nothing is set
+			if (viewPresentationAttribute == null)
+			{
+				viewPresentationAttribute = new MvxPanelPresentationAttribute(MvxPanelEnum.Center, MvxPanelHintType.ActivePanel, true);
+			}
+
             switch (viewPresentationAttribute.HintType)
             {
 				case MvxPanelHintType.PopToRoot:


### PR DESCRIPTION
Handle default behaviour for SidePanel presenter instead of showing a null reference exception
