### PR TITLE
Issue 51 - Fix bug where left and right menu buttons always shown

### DIFF
--- a/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
@@ -12,7 +12,11 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
 
             var topViewController = sidebarPanelController.NavigationController.TopViewController;
 
-            if (sidebarPanelController.LeftSidebarController != null)
+            // Make there are currently no left or right buttons
+            topViewController.NavigationItem.SetLeftBarButtonItem(null, true);
+            topViewController.NavigationItem.SetRightBarButtonItem(null, true);
+
+            if (sidebarPanelController.HasLeftMenu)
             {
                 var mvxSidebarMenu = sidebarPanelController.LeftSidebarController.MenuAreaController as IMvxSidebarMenu;
                 sidebarPanelController.LeftSidebarController.MenuLocation = MenuLocations.Left;
@@ -21,7 +25,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
                 topViewController.NavigationItem.SetLeftBarButtonItem(barButtonItem, true);
             }
 
-            if (sidebarPanelController.RightSidebarController != null)
+            if (sidebarPanelController.HasRightMenu)
             {
                 var mvxSidebarMenu = sidebarPanelController.RightSidebarController.MenuAreaController as IMvxSidebarMenu;
                 sidebarPanelController.RightSidebarController.MenuLocation = MenuLocations.Right;

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvvmCross.iOS.Support.XamarinSidebar.csproj
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvvmCross.iOS.Support.XamarinSidebar.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Hints\MvxSidebarPopToRootPresentationHint.cs" />
     <Compile Include="IMvxSidebarMenu.cs" />
     <Compile Include="Extensions\ViewControllerExtensions.cs" />
+    <Compile Include="MvxInitialEmptySideMenu.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxInitialEmptySideMenu.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxInitialEmptySideMenu.cs
@@ -1,0 +1,14 @@
+﻿using UIKit;
+
+namespace MvvmCross.iOS.Support.XamarinSidebar
+{
+    /// <summary>
+    /// This is an empty dummy class used to indicate that no 
+    /// menu has been configured. This class is used because the 
+    /// Xamarin Sidebar component doesn't allow for NULL values.s
+    /// </summary>
+    public class MvxInitialEmptySideMenu
+        : UIViewController
+    {
+    }
+}

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -23,7 +23,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
         public void Initialize()
         {
-            var initialEmptySideMenu = new UIViewController();
+            var initialEmptySideMenu = new MvxInitialEmptySideMenu();
 
             LeftSidebarController = new SidebarController(_subRootViewController, NavigationController, initialEmptySideMenu);
             RightSidebarController = new SidebarController(this, _subRootViewController, initialEmptySideMenu);
@@ -46,6 +46,8 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
         public new UINavigationController NavigationController { get; private set; }
         public SidebarController LeftSidebarController { get; private set; }
         public SidebarController RightSidebarController { get; private set; }
+        public bool HasLeftMenu => LeftSidebarController != null && !(LeftSidebarController.MenuAreaController is MvxInitialEmptySideMenu);
+        public bool HasRightMenu => RightSidebarController != null && !(RightSidebarController.MenuAreaController is MvxInitialEmptySideMenu);
 
         public override void ViewDidLoad()
         {

--- a/Samples/XamarinSidebarSample/MvvmCross.iOS.Support.Core/AppStart.cs
+++ b/Samples/XamarinSidebarSample/MvvmCross.iOS.Support.Core/AppStart.cs
@@ -11,7 +11,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
         /// </summary>
         public void Start(object hint = null)
         {
-            ShowViewModel<LeftPanelViewModel>();
+            //ShowViewModel<LeftPanelViewModel>();
             ShowViewModel<RightPanelViewModel>();
             ShowViewModel<CenterPanelViewModel>();
         }

--- a/Samples/XamarinSidebarSample/MvvmCross.iOS.Support.Core/AppStart.cs
+++ b/Samples/XamarinSidebarSample/MvvmCross.iOS.Support.Core/AppStart.cs
@@ -11,7 +11,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.Core
         /// </summary>
         public void Start(object hint = null)
         {
-            //ShowViewModel<LeftPanelViewModel>();
+            ShowViewModel<LeftPanelViewModel>();
             ShowViewModel<RightPanelViewModel>();
             ShowViewModel<CenterPanelViewModel>();
         }


### PR DESCRIPTION
Fixed a bug which caused the left and right menu buttons to always be displayed, even when no menu panels were configured. This PR closes #51 .