### PR TITLE
Fix for MvxExpandableTableViewSource: GetViewForHeader adding multiple buttons

### DIFF
--- a/MvvmCross.iOS.Support/Views/MvxExpandableTableViewSource.cs
+++ b/MvvmCross.iOS.Support/Views/MvxExpandableTableViewSource.cs
@@ -128,9 +128,9 @@ namespace MvvmCross.iOS.Support.Views
 
             if (!hasHiddenButton)
             {
-				// Create a button to make the header clickable
-				var buttonFrame = header.Frame;
-				buttonFrame.Width = UIScreen.MainScreen.ApplicationFrame.Width;
+                // Create a button to make the header clickable
+                var buttonFrame = header.Frame;
+                buttonFrame.Width = UIScreen.MainScreen.ApplicationFrame.Width;
                 var hiddenButton = CreateHiddenHeaderButton(buttonFrame, section);
                 header.ContentView.AddSubview(hiddenButton);
             }
@@ -184,7 +184,7 @@ namespace MvvmCross.iOS.Support.Views
         protected abstract override UITableViewCell GetOrCreateCellFor(UITableView tableView, NSIndexPath indexPath, object item);
     }
 
-    public class HiddenHeaderButton : UIButton 
+    public class HiddenHeaderButton : UIButton
     {
         public HiddenHeaderButton(CGRect frame) : base(frame) { }
     }


### PR DESCRIPTION
This fixes #50 also fixes the hidden header button not fitting the whole of the table cell size on iphone 6/7 plus