### PR TITLE
Feature/false warning

### DIFF
--- a/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/Extensions/ViewControllerExtensions.cs
@@ -10,11 +10,9 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
         {
             UIBarButtonItem barButtonItem;
 
-            var topViewController = sidebarPanelController.NavigationController.TopViewController;
-
             // Make there are currently no left or right buttons
-            topViewController.NavigationItem.SetLeftBarButtonItem(null, true);
-            topViewController.NavigationItem.SetRightBarButtonItem(null, true);
+            viewController.NavigationItem.SetLeftBarButtonItem(null, true);
+            viewController.NavigationItem.SetRightBarButtonItem(null, true);
 
             if (sidebarPanelController.HasLeftMenu)
             {
@@ -22,7 +20,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
                 sidebarPanelController.LeftSidebarController.MenuLocation = MenuLocations.Left;
                 barButtonItem = CreateBarButtonItem(sidebarPanelController.LeftSidebarController, mvxSidebarMenu);
 
-                topViewController.NavigationItem.SetLeftBarButtonItem(barButtonItem, true);
+                viewController.NavigationItem.SetLeftBarButtonItem(barButtonItem, true);
             }
 
             if (sidebarPanelController.HasRightMenu)
@@ -32,7 +30,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar.Extensions
                 barButtonItem = CreateBarButtonItem(sidebarPanelController.RightSidebarController, mvxSidebarMenu);
 
 
-                topViewController.NavigationItem.SetRightBarButtonItem(barButtonItem, true);
+                viewController.NavigationItem.SetRightBarButtonItem(barButtonItem, true);
             }
         }
 

--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPanelController.cs
@@ -10,6 +10,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
     public class MvxSidebarPanelController : UIViewController, IMvxSideMenu
     {
         private readonly UIViewController _subRootViewController;
+        private bool _isInitializing;
         private bool _isInitialized;
 
         public bool StatusBarHidden { get; set; }
@@ -23,24 +24,32 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
 
         public void Initialize()
         {
-            var initialEmptySideMenu = new MvxInitialEmptySideMenu();
+            _isInitializing = true;
 
-            LeftSidebarController = new SidebarController(_subRootViewController, NavigationController, initialEmptySideMenu);
-            RightSidebarController = new SidebarController(this, _subRootViewController, initialEmptySideMenu);
-
-            LeftSidebarController.StateChangeHandler += (object sender, bool e) =>
+            try
             {
-                if (ToggleStatusBarHiddenOnOpen)
-                    ToggleStatusBarStatus();
-            };
+                var initialEmptySideMenu = new MvxInitialEmptySideMenu();
 
-            RightSidebarController.StateChangeHandler += (object sender, bool e) =>
+                LeftSidebarController = new SidebarController(_subRootViewController, NavigationController, initialEmptySideMenu);
+                RightSidebarController = new SidebarController(this, _subRootViewController, initialEmptySideMenu);
+
+                LeftSidebarController.StateChangeHandler += (object sender, bool e) =>
+                {
+                    if (ToggleStatusBarHiddenOnOpen)
+                        ToggleStatusBarStatus();
+                };
+
+                RightSidebarController.StateChangeHandler += (object sender, bool e) =>
+                {
+                    if (ToggleStatusBarHiddenOnOpen)
+                        ToggleStatusBarStatus();
+                };
+            }
+            finally
             {
-                if (ToggleStatusBarHiddenOnOpen)
-                    ToggleStatusBarStatus();
-            };
-
-            _isInitialized = true;
+                _isInitializing = false;
+                _isInitialized = true;
+            }
         }
 
         public new UINavigationController NavigationController { get; private set; }
@@ -53,7 +62,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebar
         {
             base.ViewDidLoad();
 
-            if (!_isInitialized)
+            if (!_isInitialized && !_isInitializing)
             {
                 Mvx.Trace(MvxTraceLevel.Warning, "The instance of 'MvxSidebarPanelController' class is not initialized. Showing or hiding the sidemenu could show unexpected behaviour. Please call the 'Initialize()' method after constructing the 'MvxSidebarPanelController' class.");
             }


### PR DESCRIPTION
While the "MvxSidebarPanelController" is being initialised it shows a warning that the same class is not yet initialised. In this case the warning is shown incorrectly. This PR will make sure the warning is only shown when the "MvxSidebarPanelController" really is not initialised (which should only be the case when you implement a custom presenter).