### PR TITLE
Feature/automatically hide menu

### DIFF
--- a/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
+++ b/MvvmCross.iOS.Support.XamarinSidebar/MvxSidebarPresenter.cs
@@ -79,6 +79,12 @@
                     ChangePresentation(new MvxSidebarActivePanelPresentationHint(viewPresentationAttribute.Panel, RootViewController, viewController));
                     break;
             }
+
+            if (!viewPresentationAttribute.ShowPanel)
+            {
+                var menu = Mvx.Resolve<IMvxSideMenu>();
+                menu?.Close();
+            }
         }
 
         public override void Close(IMvxViewModel toClose)

--- a/Samples/XamarinSidebarSample/MvvmCross.iOS.Support.Sidebar/Views/ExampleMenuItemView.cs
+++ b/Samples/XamarinSidebarSample/MvvmCross.iOS.Support.Sidebar/Views/ExampleMenuItemView.cs
@@ -8,7 +8,7 @@ namespace MvvmCross.iOS.Support.XamarinSidebarSample.iOS.Views
     using UIKit;
 
     [Register("ExampleMenuItemView")]
-    [MvxPanelPresentation(MvxPanelEnum.Center, MvxPanelHintType.ResetRoot, true)]
+    [MvxPanelPresentation(MvxPanelEnum.Center, MvxPanelHintType.ResetRoot, false)]
     public class ExampleMenuItemView : BaseViewController<ExampleMenuItemViewModel>
     {
         public override void ViewDidLoad()


### PR DESCRIPTION
At the moment the menu stays open when you navigate away from it and the developer needs to specifically call close to hide it. With this PR the menu will automatically close unless the developer indicates (using the ShowPanel property on the MvxPanelAttribute class) that the menu should be kept open.

You can see this in action in the sample project. When navigating to the "Master view" the menu stays open. However when you navigate to the "Example view" the menu automatically closes.